### PR TITLE
Making tests run on php 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,9 @@ language: php
 
 sudo: false
 
-php:
-  - 7
-  - 7.1
-  - 7.2
-  - nightly
-
-env: TMPDIR=/tmp USE_XDEBUG=false
+env:
+  global:
+    - COMPOSER_ARGS="" TMPDIR=/tmp USE_XDEBUG=false
 
 branches:
   only:
@@ -16,7 +12,7 @@ branches:
 
 install:
   - phpenv rehash
-  - travis_retry composer install --no-interaction --prefer-source
+  - travis_retry composer update --no-interaction --prefer-source $COMPOSER_ARGS
 
 stages:
   - test
@@ -35,18 +31,34 @@ jobs:
   allow_failures:
     - php: nightly
   include:
+    - php: 7
+      env: COMPOSER_ARGS="--prefer-lowest"
+    - php: 7
+    - php: 7.1
+      env: COMPOSER_ARGS="--prefer-lowest"
+    - php: 7.1
+    - php: 7.2
+      env: COMPOSER_ARGS="--prefer-lowest"
+    - php: 7.2
+    - php: nightly
+      env: COMPOSER_ARGS="--ignore-platform-reqs --prefer-lowest"
+    - php: nightly
+      env: COMPOSER_ARGS="--ignore-platform-reqs"
+
     - stage: style check
-      php: 7.1
+      php: 7.2
       env: TMPDIR=/tmp USE_XDEBUG=false
       script:
         - composer style-check
+
     - stage: phpstan analysis
-      php: 7.1
+      php: 7.2
       env: TMPDIR=/tmp USE_XDEBUG=false
       script:
         - composer phpstan
+
     - stage: test with coverage
-      php: 7.1
+      php: 7.2
       env: TMPDIR=/tmp USE_XDEBUG=true CC_TEST_REPORTER_ID=d5fe0cce47cd025e7f2af685bccbb7c416bd513d60de5dae63c87c571334bd3e
       before_script:
         - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter


### PR DESCRIPTION
Zend_Form has some PHP 7.3 warnings in the tests, trying to get the tests to run against php 7.3 (nightly) and will resolve the warnings.